### PR TITLE
docs: fix incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Omni currently supports 34 applications. You can find them below:
 ### Text Editors
 
 - [GNU Emacs](https://github.com/getomni/emacs)
-- [Neovim](https://github.com/neovim/neovim)
+- [Neovim](https://github.com/getomni/neovim)
 - [Notepad++](https://github.com/getomni/notepad-plus-plus)
 
 ### Unix


### PR DESCRIPTION
Link for Neovim links to the repo of the editor itself. Fix URL into the
theme repo.