### PR TITLE
docs: add Ghostty omni theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Dark theme created by <a href="https://rocketseat.com.br?ref=omnitheme">Rocketse
 
 ## Themes
 
-Omni currently supports 34 applications. You can find them below:
+Omni currently supports 35 applications. You can find them below:
 
 ### Browsers
 
@@ -30,6 +30,7 @@ Omni currently supports 34 applications. You can find them below:
 
 - [Alacritty](https://github.com/getomni/alacritty)
 - [Gnome Terminal](https://github.com/getomni/gnome-terminal)
+- [Ghostty](https://github.com/JonRC/ghostty)
 - [Hyper](https://github.com/getomni/hyper)
 - [iTerm2](https://github.com/getomni/iterm)
 - [Kitty](https://github.com/getomni/kitty)


### PR DESCRIPTION
## Summary

- Adds [Ghostty](https://ghostty.org) to the Terminal Emulators section in the README
- Updates the theme count from 34 to 35

Theme repository: https://github.com/JonRC/ghostty

Closes #68